### PR TITLE
Travis - remove ruby 2.2.x builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.2.5
   - 2.3.1
 
 services:


### PR DESCRIPTION
Deployment systems are now running 2.3.x