### PR TITLE
Move method #remote_node_bags from SyncReplications to Sync

### DIFF
--- a/lib/dpn/workers/sync.rb
+++ b/lib/dpn/workers/sync.rb
@@ -63,6 +63,17 @@ module DPN
         def last_success_update
           job_data.last_success_update(remote_node.namespace)
         end
+
+        # GET local node bag data that belongs to a remote node
+        # @return [Array] bag data
+        def remote_node_bags
+          bags = []
+          bag_query = { admin_node: remote_node.namespace }
+          local_client.bags(bag_query) do |response|
+            bags << response.body if response.success?
+          end
+          bags.flatten
+        end
     end
   end
 end

--- a/lib/dpn/workers/sync_replications.rb
+++ b/lib/dpn/workers/sync_replications.rb
@@ -38,17 +38,6 @@ module DPN
           success.all? ? last_success_update : false
         end
 
-        # GET local node bag data that belongs to a remote node
-        # @return [Array] bag data
-        def remote_node_bags
-          bags = []
-          bag_query = { admin_node: remote_node.namespace }
-          local_client.bags(bag_query) do |response|
-            bags << response.body if response.success?
-          end
-          bags.flatten
-        end
-
         # @return [Boolean] replicate from remote node
         def replicate_remote_node?
           local_node.update


### PR DESCRIPTION
This will pave the way to changes in the SyncDigests so that it only tries to retrieve digests for bags that exist in the local registry.