### PR TITLE
Replace rsync with systemu call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'rake'
 gem 'dpn-bagit', '~>0.3'
 gem 'dpn-client', '~>2.0'
 gem 'rpairtree'
-gem 'rsync'
+gem 'systemu', '~> 2.6'
 
 group :development do
   gem 'thin' # app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    app_version_tasks (0.2.2)
+    app_version_tasks (0.2.3)
       git (~> 1.3)
     ast (2.3.0)
     axiom-types (0.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rsync (1.0.9)
     rubocop (0.46.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
@@ -185,6 +184,7 @@ GEM
     sshkit (1.11.4)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    systemu (2.6.5)
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -238,7 +238,6 @@ DEPENDENCIES
   reek
   rpairtree
   rspec
-  rsync
   rubocop
   rubocop-rspec
   sidekiq
@@ -246,6 +245,7 @@ DEPENDENCIES
   simplecov
   sinatra
   single_cov
+  systemu (~> 2.6)
   thin
   vcr
   webmock

--- a/app/dpn_sync.rb
+++ b/app/dpn_sync.rb
@@ -5,7 +5,7 @@ require_relative 'monitors'
 ##
 # DPN Registry Sync
 class DpnSync < Sinatra::Base
-  VERSION = '0.4.3'.freeze
+  VERSION = '0.4.4'.freeze
 
   set :app_file, __FILE__
   set :root, File.expand_path(File.join(File.dirname(__FILE__), '..'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,14 @@ RSpec.configure do |config|
   config.include RSpecMixin
   config.include DPN::Fixtures
 
+  config.mock_with :rspec do |mocks|
+    # This option should be set when all dependencies are being loaded
+    # before a spec run, as is the case in a typical spec helper. It will
+    # cause any verifying double instantiation for a class that does not
+    # exist to raise, protecting against incorrectly spelt names.
+    mocks.verify_doubled_constant_names = true
+  end
+
   config.before(:each) do
     allow(Logger).to receive(:new).and_return(null_logger)
     allow(Sidekiq).to receive(:logger).and_return(null_logger)


### PR DESCRIPTION
The rsync gem has limited functionality and bag transfers are failing.  Attempting to replace it with a direct system call to rsync.